### PR TITLE
Update README to point to personal website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,22 @@
 # Hi! I'm Rhuan Barreto! 👋
 
-I'm an engineer that loves to solve problems using technology. Programming is the tool I use the most for solving them. But my life is/was not only about programming.
-I started programming very early, since I was 10 years old. Feel free to contact me on my social platforms or email.
+Principal Software Engineer & Cloud Architect based in Stavanger, Norway.
 
-## Technologies I work today
+I'm an engineer that loves to solve problems using technology. Programming is the tool I use the most for solving them — and I've been at it since I was 10 years old. My background bridges hardware engineering (subsea systems, metallurgy) with modern cloud architecture and DevOps.
 
-My main Technologies as of today (May 2024) are:
+## What I Work With
 
-- Frontend
-  - [Vanilla Javascript](http://vanilla-js.com/) for very simple applications
-  - [Typescript](https://www.typescriptlang.org/) for enterprise (structured) applications
-  - [React](https://beta.reactjs.org/) bundled with Webpack/Vite
-  - [TanStack Query](https://tanstack.com/query/v4) for server-side state
-  - [State Colocation](https://kentcdodds.com/blog/state-colocation-will-make-your-react-app-faster) and [Jotai](https://jotai.org/) when a global state is needed
-  - Deployment using Github Pages, Netlify, Vercel, Cludflare Pages, or a simple Nginx container. The simpler the better.
-  - [Storybook](https://storybook.js.org/) for full frontend development. I'm all-in for component based development and SOLID for frontends
-- Backend
-  - [Bun](https://bun.sh/) - Replacing Node for Bun was one of the best improvements in the JS ecossystem
-  - [PostgrREST](https://postgrest.org/) - Super fast DB abstraction in a REST API.
-  - [ElysiaJS](https://elysiajs.com/) for backends if we don't need a simple CRUD REST API
-  - Python for Data Science-based workloads - Using [FastAPI](https://fastapi.tiangolo.com/) as a spec-first framework
-  - Deployment using docker containers that can be deployed to any cloud-specific service (Azure, GCP, AWS) or using Kubernetes
-- Infra
-  - [Pulumi](https://www.pulumi.com/) - Infra as a code done in the right way with access to all programming primitives without having to learn another language.
-  - [Pants](https://pantsbuild.org/) - Python monorepo management. The right tool for solving the right problem. No need for Bazel. Very specific to all the python primitives.
-  - [Moon](https://moonrepo.dev/docs) - Typescript monorepo management made easy. Blazing fast. Task orchestration made very easy.
+- **Cloud & Infrastructure** — Azure, Pulumi (IaC), Docker / Kubernetes, CI/CD Pipelines
+- **Languages** — TypeScript, Python, JavaScript, Ruby, SQL, PHP, C#
+- **Frontend** — React, TanStack (Query, Start, Form), Tailwind CSS, Storybook, Astro
+- **Backend** — Bun / ElysiaJS, Hono, FastAPI, Rails, PostgREST
+- **DevOps** — Observability / OpenTelemetry, Monorepo tooling (Pants, Moon), Grafana
+- **Leadership** — Architecture Design, Team Leadership, DevX, Scrum / Agile
 
-## Technologies I have worked with
+## Links
 
-- ASP (Not ASP.NET!) - After reading a book in the 2000s, I started with my first server-side scripting language. Not so long after, I discovered PHP and fell in love for it
-- PHP - After reading the [PHP & MySQL Bible](https://www.wiley.com/en-ie/PHP5+and+MySQL+Bible-p-9780764557460) book, I jumped all-in into PHP. Wordpress is still my most used CMS. Made many applications in CodeIgniter and CakePHP. Laravel was not a thing in that time.
-- [jQuery](https://jquery.com/) - Does someone still remember jQuery was a thing in the 2000s?
-- AngularJS - A brief journey on AngularJS for making simple applications. This journey also included the usage of Ionic Framework
-- C for PIC microcontrollers - Using PIC16F for temperature sensor signal conditioning
-- C for Arduino - I always played with automation projects, from steering a sailboat to running ping tests on my local network
-- C++ - Low level stuff, always when you need it
-- C# - You always need to interface with some legacy code that only runs on Windows, right?
-- [Ruby on Rails](https://rubyonrails.org/) for complex problems, like integrating with legacy applications
-- [Parse Platform](https://parseplatform.org/) - No need for making full CRUD backends for simple data
-- [CosmosDB REST API](https://learn.microsoft.com/en-us/rest/api/cosmos-db/) - They even abstract the DB for you. The rest (pun intended) is simple.
-- [Koa](https://koajs.com/) for middleware backends if previous options cannot solve the problem
-- Python for Data Science-based workloads - Using [Connexion](https://connexion.readthedocs.io/en/latest/) as a spec-first framework
-
-## Important Links
-
-- [LinkedIN](https://www.linkedin.com/in/rhuanbarreto/)
-- [My Blog](https://rhuan.no)
-
-## Want to know more about me?
-
-Read my principles: https://github.com/rhuanbarreto/rhuanbarreto/wiki/Principles/
+- 🌐 **Website & Blog** — [rhuan.com.br](https://rhuan.com.br)
+- 💼 **LinkedIn** — [linkedin.com/in/rhuanbarreto](https://www.linkedin.com/in/rhuanbarreto/)
+- 📧 **Email** — [rhuan@barreto.work](mailto:rhuan@barreto.work)
+- 📝 **My Principles** — [rhuan.com.br/principles](https://rhuan.com.br/principles)
+- 📡 **RSS Feed** — [rhuan.com.br/rss.xml](https://rhuan.com.br/rss.xml)


### PR DESCRIPTION
## Summary

- Replace detailed technology lists with a concise skills summary
- Add links to the new website at [rhuan.com.br](https://rhuan.com.br) for portfolio, blog, and principles
- Update principles link from GitHub wiki to the website's dedicated page
- Keep the intro and tone consistent with the rest of the online presence

## Before → After

**Before:** Long categorized tech lists (frontend, backend, infra) with individual tool descriptions + links to LinkedIn and old blog  
**After:** Clean one-liner skill groups + links to website, LinkedIn, email, principles page, and RSS feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)